### PR TITLE
Fix wrong type for denoising_strength

### DIFF
--- a/workers/DreamBooth-v1/docker_example/handler.py
+++ b/workers/DreamBooth-v1/docker_example/handler.py
@@ -147,7 +147,7 @@ INFERENCE_SCHEMA = {
         'default': False
     },
     'denoising_strength': {
-        'type': int,
+        'type': float,
         'required': False,
         'default': 0
     },


### PR DESCRIPTION
The denoising strength for the high_res fix expects values in float format like 0.4, 0.7, etc. Therefore I changed the int value to float