### PR TITLE
Randomize seed if it was not passed.

### DIFF
--- a/workers/Openjourney/cog_example/predict.py
+++ b/workers/Openjourney/cog_example/predict.py
@@ -139,6 +139,10 @@ class Predictor(BasePredictor):
         '''
         Run a single prediction on the model
         '''
+        if seed is None:
+            seed = int.from_bytes(os.urandom(2), "big")
+        print(f"Using seed: {seed}")
+        
         if width * height > 786432:
             raise ValueError(
                 "Maximum size is 1024x768 or 768x1024 pixels, because of memory limits."


### PR DESCRIPTION
Currently, the seed is defaulted to `None` and is not initialized like in other workers. So if the seed was not passed in the request, the job fails in L:178 `generator = torch.Generator("cuda").manual_seed(seed)`.

The proposed change init the seed just like in the other examples: 
```
if seed is None:
    seed = int.from_bytes(os.urandom(2), "big")
```